### PR TITLE
README.md: Fix install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 ## Install
 
-    go get -u github.com/vrischmann/logfmt/cmd/lgrep
-    go get -u github.com/vrischmann/logfmt/cmd/lcut
-    go get -u github.com/vrischmann/logfmt/cmd/lpretty
-    go get -u github.com/vrischmann/logfmt/cmd/lsort
+    go install github.com/vrischmann/logfmt/cmd/lgrep@latest
+    go install github.com/vrischmann/logfmt/cmd/lcut@latest
+    go install github.com/vrischmann/logfmt/cmd/lpretty@latest
+    go install github.com/vrischmann/logfmt/cmd/lsort@latest
 
 ## Library
 


### PR DESCRIPTION
The install commands provided in `README.md` seem to be outdated and fail with the newest go toolchain installed (`go version go1.21.3 darwin/amd64`):

```bash
$ go get -u github.com/vrischmann/logfmt/cmd/lgrep
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

This PR fixes the install commands.